### PR TITLE
大文字小文字

### DIFF
--- a/4-7/main.rb
+++ b/4-7/main.rb
@@ -1,0 +1,3 @@
+str = ARGV[0].split(",").map{|factor| factor.downcase}.sort
+
+puts str.select{|s| s.include?("a")}


### PR DESCRIPTION
4-7問題解きました。
１つ目のコマンドライン引数を配列に変換し、２つ目のコマンドライン引数が含まれているもの(ただし大文字小文字の区別しない)だけの配列にしてください。また、アルファベット順に並べて全て小文字で表示してください。